### PR TITLE
Picard as a prototype, not a starter theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Picard
 
-Picard is a prototype of WordPress theme that makes use of [React](http://facebook.github.io/react/) and the new [WP-API](http://wp-api.org/) which, at some point, will be going into WordPress core.
+Picard is a prototype WordPress theme that makes use of [React](http://facebook.github.io/react/) and the new [WP-API](http://wp-api.org/) which, at some point, will be going into WordPress core.
 
 ## Getting Started
 


### PR DESCRIPTION
As discussed in Slack, we should keep Picard as a prototype, not a starter theme. It's too early to make a starter theme at this point. (Remember? We made _s after a good few years since we have a solid default theme.)
