### PR TITLE
Build post navigation in React

### DIFF
--- a/components/content/loop/loop.jsx
+++ b/components/content/loop/loop.jsx
@@ -7,7 +7,8 @@ var React = require( 'react/addons' ),
 /**
  * Internal dependencies
  */
-var Hentry = require( './hentry/hentry.jsx' );
+var Hentry = require( './hentry/hentry.jsx' ),
+	PostNavigation = require( './navigation/post-navigation.jsx');
 
 var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
@@ -26,16 +27,17 @@ Loop = React.createClass({
 		}
 
 		var postNodes = this.props.data.map( function ( post ) {
-
-			// Get next and previous post links
-			if ( context === 'single' ) {
-				next = post.next_post;
-				previous = post.previous_post;
-			}
-
 			return (
 				<Hentry key={post.ID} id={post.ID} post_class={post.post_class} link={post.link} title={post.title} date={post.date} content={post.content} featured_image={ post.featured_image } context={ context } showExtra={ showExtra } />
 			);
+		});
+
+		var navigationNodes = this.props.data.map( function ( post ) {
+			if ( context === 'single' ) {
+				return (
+					<PostNavigation previous_post_url={post.previous_post_url} previous_post_title={post.previous_post_title} next_post_url={post.next_post_url} next_post_title={post.next_post_title} />
+				);
+			}
 		});
 
 		return (
@@ -43,12 +45,7 @@ Loop = React.createClass({
 				<ReactCSSTransitionGroup transitionName="picard">
 					{ postNodes }
 				</ReactCSSTransitionGroup>
-				<nav className="navigation post-navigation" role="navigation">
-					<div className="nav-links">
-						<div className="nav-next" dangerouslySetInnerHTML={{__html: next}} />
-						<div className="nav-previous" dangerouslySetInnerHTML={{__html: previous}} />
-					</div>
-				</nav>
+				{ navigationNodes }
 			</div>
 		);
 	}

--- a/components/content/loop/navigation/post-navigation.jsx
+++ b/components/content/loop/navigation/post-navigation.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react/addons' );
+
+/**
+ * Renders links to the next and previous posts.
+ */
+PostNavigation = React.createClass({
+
+	render: function() {
+		var previousPostLink;
+		if ( this.props.previous_post_url ) {
+			previousPostLink = <div className="nav-previous">
+				<a href={this.props.previous_post_url} rel="prev">
+					<span className="screen-reader-text">{this.props.previous_post_title}</span>
+				</a>
+			</div>;
+		}
+
+		var nextPostLink;
+		if ( this.props.next_post_url ) {
+			nextPostLink = <div className="nav-next">
+				<a href={this.props.next_post_url} rel="next">
+					<span className="screen-reader-text">{this.props.next_post_title}</span>
+				</a>
+			</div>;
+		}
+
+		return (
+			<nav className="navigation post-navigation" role="navigation">
+				<div className="nav-links">
+					{ previousPostLink }
+					{ nextPostLink }
+				</div>
+			</nav>
+		)
+	}
+});
+
+module.exports = PostNavigation;

--- a/functions.php
+++ b/functions.php
@@ -131,21 +131,19 @@ function picard_get_json( $_post ) {
 		// Get next and previous links
 		global $post;
 		$post = get_post( $_post['ID'] );
-		ob_start();
-		echo get_next_post_link();
-		$next_post_link = ob_get_contents();
-		ob_end_clean();
-		$next_post_link = str_replace( 'rel="next">', 'rel="next"><span class="screen-reader-text">', $next_post_link );
-		$next_post_link = str_replace( '</a> &raquo;', '</span></a>', $next_post_link );
-		ob_start();
-		echo get_previous_post_link();
-		$previous_post_link = ob_get_contents();
-		ob_end_clean();
-		$previous_post_link = str_replace( 'rel="prev">', 'rel="prev"><span class="screen-reader-text">', $previous_post_link );
-		$previous_post_link = str_replace( '</a>', '</span></a>', $previous_post_link );
-		$previous_post_link = str_replace( '&laquo; ', '', $previous_post_link );
-		$_post['next_post'] = $next_post_link;
-		$_post['previous_post'] = $previous_post_link;
+
+		$previous_post = get_adjacent_post( false, '', true );
+		if ( $previous_post ) {
+			$_post['previous_post_url']   = get_permalink( $previous_post );
+			$_post['previous_post_title'] = get_the_title( $previous_post );
+		}
+
+		$next_post = get_adjacent_post( false, '', false );
+		if ( $next_post ) {
+			$_post['next_post_url']   = get_permalink( $next_post );
+			$_post['next_post_title'] = get_the_title( $next_post );
+		}
+
 	}
 	return $_post;
 }


### PR DESCRIPTION
Adds a new `PostNavigation` component for displaying next and previous
post navigation on single pages.

Building this in React avoids having to dangerously render HTML.