### PR TITLE
Update gulp-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-load-plugins": "~0.9.0",
     "gulp-minify-css": "~1.0.0",
     "gulp-notify": "^2.2.0",
-    "gulp-sass": "~1.3.3",
+    "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "~1.2.8",
     "gulp-uglify": "~1.3.0",
     "gulp-util": "~3.0.1",


### PR DESCRIPTION
To avoid undesirable errors when build like:

```
Error: `libsass` bindings not found. Try reinstalling `node-sass`?
    at getBinding (/Applications/MAMP/htdocs/wordpress/react/wp-content/themes/Picard/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:22:11)
    at Object.<anonymous> (/Applications/MAMP/htdocs/wordpress/react/wp-content/themes/Picard/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:188:23)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Applications/MAMP/htdocs/wordpress/react/wp-content/themes/Picard/node_modules/gulp-sass/index.js:3:17)
    at Module._compile (module.js:435:26)
```

Installing `^2` versions solve this.
